### PR TITLE
feat: Biblioteca Anima — painel administrativo + migration Supabase

### DIFF
--- a/app/dashboard/biblioteca-anima/page.tsx
+++ b/app/dashboard/biblioteca-anima/page.tsx
@@ -1,0 +1,5 @@
+import { AnimaLibraryPanel } from "@/components/dashboard/anima-library-panel";
+
+export default function BibliotecaAnimaPage() {
+  return <AnimaLibraryPanel />;
+}

--- a/components/dashboard/anima-library-panel.tsx
+++ b/components/dashboard/anima-library-panel.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createClient } from "@/src/lib/supabase/client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type ElementType = "fogo" | "agua" | "planta";
+
+type Anima = {
+  id: string;
+  species: string;
+  evolutionary_line: string;
+  next_evolution_id: string | null;
+  attack: number;
+  defense: number;
+  max_health: number;
+  attack_speed_seconds: number;
+  critical_chance: number;
+  image_url: string | null;
+  attribute: ElementType;
+  created_at: string;
+};
+
+type FormValues = {
+  species: string;
+  evolutionary_line: string;
+  next_evolution_id: string;
+  attack: string;
+  defense: string;
+  max_health: string;
+  attack_speed_seconds: string;
+  critical_chance: string;
+  image_url: string;
+  attribute: ElementType;
+};
+
+const initialForm: FormValues = {
+  species: "",
+  evolutionary_line: "",
+  next_evolution_id: "",
+  attack: "",
+  defense: "",
+  max_health: "",
+  attack_speed_seconds: "",
+  critical_chance: "",
+  image_url: "",
+  attribute: "fogo",
+};
+
+export function AnimaLibraryPanel() {
+  const supabaseRef = useRef<ReturnType<typeof createClient> | null>(null);
+  const [animas, setAnimas] = useState<Anima[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingAnima, setEditingAnima] = useState<Anima | null>(null);
+  const [form, setForm] = useState<FormValues>(initialForm);
+
+  const evolutionaryLineOptions = useMemo(
+    () => Array.from(new Set(animas.map((item) => item.evolutionary_line))).sort((a, b) => a.localeCompare(b)),
+    [animas],
+  );
+
+  const fetchAnimas = useCallback(async () => {
+    if (!supabaseRef.current) return;
+
+    setLoading(true);
+    const { data, error: fetchError } = await supabaseRef.current
+      .from("animas")
+      .select("*")
+      .order("created_at", { ascending: false });
+
+    if (fetchError) {
+      setError(fetchError.message);
+      setLoading(false);
+      return;
+    }
+
+    setAnimas((data ?? []) as Anima[]);
+    setError(null);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    supabaseRef.current = createClient();
+    void fetchAnimas();
+  }, [fetchAnimas]);
+
+  function openCreateModal() {
+    setForm(initialForm);
+    setEditingAnima(null);
+    setIsCreateOpen(true);
+  }
+
+  function openEditModal(anima: Anima) {
+    setEditingAnima(anima);
+    setForm({
+      species: anima.species,
+      evolutionary_line: anima.evolutionary_line,
+      next_evolution_id: anima.next_evolution_id ?? "",
+      attack: String(anima.attack),
+      defense: String(anima.defense),
+      max_health: String(anima.max_health),
+      attack_speed_seconds: String(anima.attack_speed_seconds),
+      critical_chance: String(anima.critical_chance),
+      image_url: anima.image_url ?? "",
+      attribute: anima.attribute,
+    });
+    setIsCreateOpen(true);
+  }
+
+  async function onImageInput(file: File | null) {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        const imageUrl = reader.result;
+        setForm((previous) => ({ ...previous, image_url: imageUrl }));
+      }
+    };
+    reader.readAsDataURL(file);
+  }
+
+  async function saveAnima() {
+    if (!form.species || !form.evolutionary_line) {
+      setError("Preencha espécie e linha evolutiva.");
+      return;
+    }
+
+    const payload = {
+      species: form.species,
+      evolutionary_line: form.evolutionary_line,
+      next_evolution_id: form.next_evolution_id || null,
+      attack: Number(form.attack),
+      defense: Number(form.defense),
+      max_health: Number(form.max_health),
+      attack_speed_seconds: Number(form.attack_speed_seconds),
+      critical_chance: Number(form.critical_chance),
+      image_url: form.image_url || null,
+      attribute: form.attribute,
+    };
+
+    if (!supabaseRef.current) return;
+
+    const response = editingAnima
+      ? await supabaseRef.current.from("animas").update(payload).eq("id", editingAnima.id)
+      : await supabaseRef.current.from("animas").insert(payload);
+
+    if (response.error) {
+      setError(response.error.message);
+      return;
+    }
+
+    setIsCreateOpen(false);
+    setForm(initialForm);
+    setEditingAnima(null);
+    await fetchAnimas();
+  }
+
+  async function deleteAnima(id: string) {
+    if (!supabaseRef.current) return;
+
+    const { error: deleteError } = await supabaseRef.current.from("animas").delete().eq("id", id);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      return;
+    }
+
+    await fetchAnimas();
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-4">
+          <div>
+            <CardTitle>Biblioteca Anima</CardTitle>
+            <CardDescription>Painel administrativo para gestão visual da biblioteca de criaturas.</CardDescription>
+          </div>
+          <Button onClick={openCreateModal}>Novo Anima</Button>
+        </CardHeader>
+        <CardContent>
+          {error && <p className="mb-4 text-sm text-red-500">{error}</p>}
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Carregando biblioteca...</p>
+          ) : (
+            <div className="overflow-x-auto rounded-lg border">
+              <table className="min-w-full text-sm">
+                <thead className="bg-muted/60">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Imagem</th>
+                    <th className="px-3 py-2 text-left">Espécie</th>
+                    <th className="px-3 py-2 text-left">Linha Evolutiva</th>
+                    <th className="px-3 py-2 text-left">Próxima Evolução</th>
+                    <th className="px-3 py-2 text-left">Atributos</th>
+                    <th className="px-3 py-2 text-left">Ação</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {animas.map((anima) => (
+                    <tr key={anima.id} className="border-t">
+                      <td className="px-3 py-2">
+                        {anima.image_url ? (
+                          <img src={anima.image_url} alt={anima.species} className="h-12 w-12 rounded-md object-cover" />
+                        ) : (
+                          <div className="h-12 w-12 rounded-md bg-muted" />
+                        )}
+                      </td>
+                      <td className="px-3 py-2 font-medium">{anima.species}</td>
+                      <td className="px-3 py-2">{anima.evolutionary_line}</td>
+                      <td className="px-3 py-2">
+                        {animas.find((item) => item.id === anima.next_evolution_id)?.species ?? "-"}
+                      </td>
+                      <td className="space-y-1 px-3 py-2">
+                        <Badge>{anima.attribute}</Badge>
+                        <div className="text-xs text-muted-foreground">
+                          ATK {anima.attack} | DEF {anima.defense} | HP {anima.max_health}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          Vel {anima.attack_speed_seconds}s | Crit {anima.critical_chance}%
+                        </div>
+                      </td>
+                      <td className="px-3 py-2">
+                        <div className="flex gap-2">
+                          <Button variant="outline" size="sm" onClick={() => openEditModal(anima)}>
+                            Editar
+                          </Button>
+                          <Button variant="destructive" size="sm" onClick={() => void deleteAnima(anima.id)}>
+                            Excluir
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {isCreateOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <Card className="max-h-[90vh] w-full max-w-3xl overflow-y-auto">
+            <CardHeader>
+              <CardTitle>{editingAnima ? "Editar Anima" : "Criar Anima"}</CardTitle>
+              <CardDescription>Cadastro completo de atributos da criatura.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="species">Espécie</Label>
+                <Input
+                  id="species"
+                  value={form.species}
+                  onChange={(event) => setForm((prev) => ({ ...prev, species: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="evolutionary_line">Linha Evolutiva</Label>
+                <Input
+                  id="evolutionary_line"
+                  list="evolutionary-lines"
+                  value={form.evolutionary_line}
+                  onChange={(event) =>
+                    setForm((prev) => ({ ...prev, evolutionary_line: event.target.value }))
+                  }
+                />
+                <datalist id="evolutionary-lines">
+                  {evolutionaryLineOptions.map((item) => (
+                    <option key={item} value={item} />
+                  ))}
+                </datalist>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="next_evolution_id">Próxima Evolução</Label>
+                <select
+                  id="next_evolution_id"
+                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm"
+                  value={form.next_evolution_id}
+                  onChange={(event) =>
+                    setForm((prev) => ({ ...prev, next_evolution_id: event.target.value }))
+                  }
+                >
+                  <option value="">Sem evolução</option>
+                  {animas
+                    .filter((item) => item.id !== editingAnima?.id)
+                    .map((item) => (
+                      <option key={item.id} value={item.id}>
+                        {item.species}
+                      </option>
+                    ))}
+                </select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="attribute">Atributo</Label>
+                <select
+                  id="attribute"
+                  className="w-full rounded-md border bg-transparent px-3 py-2 text-sm"
+                  value={form.attribute}
+                  onChange={(event) =>
+                    setForm((prev) => ({ ...prev, attribute: event.target.value as ElementType }))
+                  }
+                >
+                  <option value="fogo">Fogo</option>
+                  <option value="agua">Água</option>
+                  <option value="planta">Planta</option>
+                </select>
+              </div>
+
+              <InputField label="Ataque" value={form.attack} onChange={(value) => setForm((prev) => ({ ...prev, attack: value }))} />
+              <InputField label="Defesa" value={form.defense} onChange={(value) => setForm((prev) => ({ ...prev, defense: value }))} />
+              <InputField label="Vida Máxima" value={form.max_health} onChange={(value) => setForm((prev) => ({ ...prev, max_health: value }))} />
+              <InputField
+                label="Velocidade de Ataque (segundos)"
+                value={form.attack_speed_seconds}
+                onChange={(value) => setForm((prev) => ({ ...prev, attack_speed_seconds: value }))}
+              />
+              <InputField
+                label="% Acerto Crítico"
+                value={form.critical_chance}
+                onChange={(value) => setForm((prev) => ({ ...prev, critical_chance: value }))}
+              />
+
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="image">Imagem</Label>
+                <Input id="image" type="file" accept="image/*" onChange={(event) => void onImageInput(event.target.files?.[0] ?? null)} />
+                {form.image_url && (
+                  <img src={form.image_url} alt="Preview da imagem" className="h-24 w-24 rounded-md object-cover" />
+                )}
+              </div>
+
+              <div className="flex justify-end gap-2 md:col-span-2">
+                <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
+                  Cancelar
+                </Button>
+                <Button onClick={() => void saveAnima()}>{editingAnima ? "Salvar alterações" : "Criar Anima"}</Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InputField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      <Input type="number" value={value} onChange={(event) => onChange(event.target.value)} />
+    </div>
+  );
+}

--- a/components/layout/dashboard-sidebar.tsx
+++ b/components/layout/dashboard-sidebar.tsx
@@ -1,21 +1,16 @@
 import { LogoutButton } from "@/components/layout/logout-button";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { createClient } from "@/src/lib/supabase/server";
-import { ChevronDown, Home, LayoutDashboard, Settings } from "lucide-react";
+import { Building2, LayoutDashboard, LibraryBig, Settings } from "lucide-react";
 import Link from "next/link";
 
 const links = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
-  { href: "/", label: "Landing", icon: Home },
+];
+
+const adminLinks = [
+  { href: "/dashboard/biblioteca-anima", label: "Biblioteca Anima", icon: LibraryBig },
 ];
 
 export async function DashboardSidebar() {
@@ -26,25 +21,8 @@ export async function DashboardSidebar() {
 
   return (
     <aside className="w-full border-b bg-background p-4 md:min-h-screen md:w-64 md:border-b-0 md:border-r">
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-6">
         <p className="font-semibold">Anima Online</p>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm">
-              Menu
-              <ChevronDown className="ml-2 h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuLabel>Navegação</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            {links.map((link) => (
-              <DropdownMenuItem key={link.href} asChild>
-                <Link href={link.href}>{link.label}</Link>
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
 
       <nav className="space-y-2">
@@ -59,6 +37,26 @@ export async function DashboardSidebar() {
             </Button>
           );
         })}
+
+        <details className="rounded-lg border bg-muted/30 px-2 py-1">
+          <summary className="flex cursor-pointer list-none items-center rounded-md px-2 py-2 text-sm font-medium">
+            <Building2 className="mr-2 h-4 w-4" />
+            Administrativo
+          </summary>
+          <div className="mt-1 space-y-1 pb-1 pl-2">
+            {adminLinks.map((link) => {
+              const Icon = link.icon;
+              return (
+                <Button key={link.href} asChild variant="ghost" className="w-full justify-start">
+                  <Link href={link.href}>
+                    <Icon className="mr-2 h-4 w-4" />
+                    {link.label}
+                  </Link>
+                </Button>
+              );
+            })}
+          </div>
+        </details>
       </nav>
 
       <div className="mt-6 border-t pt-4 text-sm text-muted-foreground">{user?.email}</div>

--- a/supabase/migrations/20260214053000_create_anima_library.sql
+++ b/supabase/migrations/20260214053000_create_anima_library.sql
@@ -1,0 +1,55 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.animas (
+  id uuid primary key default gen_random_uuid(),
+  species text not null unique,
+  evolutionary_line text not null,
+  next_evolution_id uuid references public.animas (id) on delete set null,
+  attack integer not null check (attack >= 0),
+  defense integer not null check (defense >= 0),
+  max_health integer not null check (max_health >= 1),
+  attack_speed_seconds numeric(4,2) not null check (attack_speed_seconds > 0),
+  critical_chance numeric(5,2) not null check (critical_chance >= 0 and critical_chance <= 100),
+  image_url text,
+  attribute text not null check (attribute in ('fogo', 'agua', 'planta')),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create or replace function public.update_timestamp()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+create trigger update_animas_timestamp
+before update on public.animas
+for each row
+execute function public.update_timestamp();
+
+alter table public.animas enable row level security;
+
+create policy "authenticated read animas"
+on public.animas
+for select
+using (auth.role() = 'authenticated');
+
+create policy "authenticated insert animas"
+on public.animas
+for insert
+with check (auth.role() = 'authenticated');
+
+create policy "authenticated update animas"
+on public.animas
+for update
+using (auth.role() = 'authenticated')
+with check (auth.role() = 'authenticated');
+
+create policy "authenticated delete animas"
+on public.animas
+for delete
+using (auth.role() = 'authenticated');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -12,7 +16,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -20,7 +24,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -30,5 +36,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Adicionar uma área administrativa para gerenciar a "Biblioteca de Animas" com CRUD visual e integração com Supabase.
- Fornecer um fluxo inicial de criação/edição/exclusão de animas e permitir upload/preview de imagens para o catálogo.

### Description
- Atualizei a sidebar removendo o item `Landing` e o dropdown `Menu`, e adicionei a seção recolhível `Administrativo` com o item `Biblioteca Anima` (`components/layout/dashboard-sidebar.tsx`).
- Criei a rota `/dashboard/biblioteca-anima` e o painel `AnimaLibraryPanel` com tabela, modal de criação/edição, preview de imagem, seleção/criação de linha evolutiva (`app/dashboard/biblioteca-anima/page.tsx` e `components/dashboard/anima-library-panel.tsx`).
- Implementei operações de list/insert/update/delete usando o cliente Supabase em modo cliente e adicionei lógica para evitar chamadas SSR quando variáveis de ambiente não estiverem presentes (`components/dashboard/anima-library-panel.tsx`).
- Adicionei migration SQL para Supabase criando a tabela `public.animas` com constraints, trigger `updated_at` e políticas RLS para usuários autenticados (`supabase/migrations/20260214053000_create_anima_library.sql`).
- Ajustei `tsconfig.json` para `jsx: "preserve"` conforme alteração necessária pelo build do Next.js.

### Testing
- Executei `npm run lint`, que passou com warnings sobre uso de `<img>` (recomendação do Next.js); resultado: success (warnings only). 
- Executei `npm run build`, que passou com warnings sobre `<img>`; resultado: success (warnings only). 
- Rodei a aplicação em dev com `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run dev` e acessei `/dashboard/biblioteca-anima`, obtendo render correto do painel (dev server OK). 
- Capturei uma screenshot automática da página usando Playwright para validação visual, que foi gerada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990073804a8832599b2c559b88b570d)